### PR TITLE
로그인 상태에 따른 nav 변경

### DIFF
--- a/src/components/mealkeat/commons/Header.tsx
+++ b/src/components/mealkeat/commons/Header.tsx
@@ -89,20 +89,22 @@ export const Header = (): JSX.Element => {
             <span>장바구니</span>
           </StyledIcon>
           {isLoggedIn ? (
-            <StyledIcon onClick={handleLogout}>
-              <img src={UserPath} alt="로그아웃 아이콘" />
-              <span>로그아웃</span>
-            </StyledIcon>
+            <>
+              <StyledIcon onClick={handleLogout}>
+                <img src={UserPath} alt="로그아웃 아이콘" />
+                <span>로그아웃</span>
+              </StyledIcon>
+              <StyledIcon onClick={() => handleProtectedRoute("/mypage/order")}>
+                <img src={MypagePath} alt="마이페이지 아이콘" />
+                <span>마이페이지</span>
+              </StyledIcon>
+            </>
           ) : (
             <StyledIcon onClick={() => navigate("/login")}>
               <img src={UserPath} alt="로그인 아이콘" />
               <span>로그인</span>
             </StyledIcon>
           )}
-          <StyledIcon onClick={() => handleProtectedRoute("/mypage/order")}>
-            <img src={MypagePath} alt="마이페이지 아이콘" />
-            <span>마이페이지</span>
-          </StyledIcon>
         </StyledIconList>
         <StyledTopNav>
           <NavMenu title="클릭 시 전체상품 페이지로 이동" onClick={() => navigate("/list")}>

--- a/src/pages/mealkeat/oauth/KakaoCallback.tsx
+++ b/src/pages/mealkeat/oauth/KakaoCallback.tsx
@@ -27,7 +27,7 @@ function KakaoCallback() {
           //spring에서 발급된 jwt localStorage 저장
           localStorage.setItem("Authorization", "Bearer " + response.data.accessToken);
           //메인 페이지로 이동
-          navigate("/", { replace: true });
+          window.location.href = "/";
         } else {
           //회원가입 페이지로 이동
           navigate("/signup", { replace: true });


### PR DESCRIPTION
## ✨ 과제 내용

- 로그인 여부에 따라 로그인/로그아웃 버튼 표시
- 로그인 여부에 따라 찜/장바구니/마이페이지 클릭시 로그인 페이지로 이동
- 로그인 여부에 따라 장바구니 개수 불러오기
- 로그아웃 클릭시 localstorage 값 비우기

## 📸 스크린샷

- 로그아웃 시
<img width="1122" alt="image" src="https://github.com/7JEON8KI/frontend/assets/99467446/f923a136-f5a0-4c6a-ad56-dfeafb3d3b21">

- 로그인 시
<img width="876" alt="image" src="https://github.com/7JEON8KI/frontend/assets/99467446/e8e0890b-353e-4c46-83b5-8c155698be80">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 혹시나 새로고침이 안된다면 redux 사용 고려
